### PR TITLE
服の登録ページと着せ替え・評価ページを分離

### DIFF
--- a/app/clothing/page.tsx
+++ b/app/clothing/page.tsx
@@ -1,0 +1,37 @@
+import { ClothingManager } from "@/components/clothing-manager"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ClothingPage() {
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center gap-4 mb-8">
+          <Link href="/">
+            <Button variant="ghost" size="sm" className="gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              プロフィール設定に戻る
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">服アイテム管理</h1>
+            <p className="text-muted-foreground">お気に入りの服を登録して、コーディネートの幅を広げましょう</p>
+          </div>
+        </div>
+
+        <div className="max-w-6xl mx-auto">
+          <ClothingManager />
+        </div>
+
+        <div className="max-w-6xl mx-auto mt-8">
+          <Link href="/styling">
+            <Button className="w-full">
+              着せ替え・スタイル分析に進む
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/styling/page.tsx
+++ b/app/styling/page.tsx
@@ -1,4 +1,3 @@
-import { ClothingManager } from "@/components/clothing-manager"
 import { DressUpEditor } from "@/components/dress-up-editor"
 import { FeedbackAnalyzer } from "@/components/feedback-analyzer"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -18,21 +17,16 @@ export default function StylingPage() {
             </Button>
           </Link>
           <div>
-            <h1 className="text-3xl font-bold text-foreground">スタイリング & 着せ替え</h1>
-            <p className="text-muted-foreground">服を登録して、着せ替えを楽しみましょう</p>
+            <h1 className="text-3xl font-bold text-foreground">着せ替え & スタイル分析</h1>
+            <p className="text-muted-foreground">登録した服で着せ替えを楽しみ、スタイルを分析しましょう</p>
           </div>
         </div>
 
-        <Tabs defaultValue="clothing" className="max-w-6xl mx-auto">
-          <TabsList className="grid w-full grid-cols-3 mb-8">
-            <TabsTrigger value="clothing">服アイテム管理</TabsTrigger>
+        <Tabs defaultValue="editor" className="max-w-6xl mx-auto">
+          <TabsList className="grid w-full grid-cols-2 mb-8">
             <TabsTrigger value="editor">着せ替えエディター</TabsTrigger>
             <TabsTrigger value="feedback">スタイル分析</TabsTrigger>
           </TabsList>
-
-          <TabsContent value="clothing">
-            <ClothingManager />
-          </TabsContent>
 
           <TabsContent value="editor">
             <DressUpEditor />
@@ -42,6 +36,14 @@ export default function StylingPage() {
             <FeedbackAnalyzer />
           </TabsContent>
         </Tabs>
+
+        <div className="max-w-6xl mx-auto mt-8">
+          <Link href="/clothing">
+            <Button variant="outline" className="w-full">
+              服アイテム管理に戻る
+            </Button>
+          </Link>
+        </div>
       </div>
     </main>
   )

--- a/components/profile-setup.tsx
+++ b/components/profile-setup.tsx
@@ -118,13 +118,21 @@ export function ProfileSetup() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <p className="text-muted-foreground">これで準備完了です。次は服を登録して着せ替えを楽しみましょう！</p>
-            <Link href="/styling">
-              <Button size="lg" className="gap-2">
-                スタイリングを始める
-                <ArrowRight className="w-4 h-4" />
-              </Button>
-            </Link>
+            <p className="text-muted-foreground">これで準備完了です。まずは服を登録してから着せ替えを楽しみましょう！</p>
+            <div className="space-y-3">
+              <Link href="/clothing">
+                <Button size="lg" className="gap-2 w-full">
+                  服アイテムを登録する
+                  <ArrowRight className="w-4 h-4" />
+                </Button>
+              </Link>
+              <Link href="/styling">
+                <Button variant="outline" size="lg" className="gap-2 w-full">
+                  着せ替え・スタイル分析へ
+                  <ArrowRight className="w-4 h-4" />
+                </Button>
+              </Link>
+            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
- /clothing: 服アイテム管理専用ページ
- /styling: 着せ替えエディターとスタイル分析専用ページ
- プロフィール設定完了後のナビゲーションを更新
- 各ページ間の移動ボタンを追加