### PR TITLE
クローゼット画面をスマートフォン最適化

### DIFF
--- a/app/clothing/page.tsx
+++ b/app/clothing/page.tsx
@@ -2,52 +2,89 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
+import { Menu, Plus, User, Shirt, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useClothingItems } from "@/hooks/use-clothing-items"
 import { AddItemDialog } from "@/components/clothing/add-item-dialog"
 import { CategoryTabs } from "@/components/clothing/category-tabs"
 import type { ClothingCategory } from "@/lib/types/clothing"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
 
 export default function ClothingPage() {
   const { items, addItem, deleteItem } = useClothingItems()
   const [activeCategory, setActiveCategory] = useState<ClothingCategory>("tops")
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
   return (
     <main className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center gap-4 mb-8">
-          <Link href="/">
-            <Button variant="ghost" size="sm" className="gap-2">
-              <ArrowLeft className="h-4 w-4" />
-              プロフィール設定に戻る
+      {/* スマートフォン用ヘッダー */}
+      <div className="sticky top-0 z-50 bg-background border-b">
+        <div className="flex items-center justify-between px-4 py-3">
+          {/* ハンバーガーメニュー */}
+          <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="sm" className="p-2">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-64">
+              <SheetHeader>
+                <SheetTitle>メニュー</SheetTitle>
+                <SheetDescription>
+                  アプリの各機能にアクセスできます
+                </SheetDescription>
+              </SheetHeader>
+              <div className="mt-6 space-y-2">
+                <Link href="/profile" onClick={() => setIsMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start gap-2">
+                    <User className="h-4 w-4" />
+                    プロフィール登録
+                  </Button>
+                </Link>
+                <Link href="/clothing" onClick={() => setIsMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start gap-2">
+                    <Shirt className="h-4 w-4" />
+                    服登録
+                  </Button>
+                </Link>
+                <Link href="/styling" onClick={() => setIsMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start gap-2">
+                    <Sparkles className="h-4 w-4" />
+                    着せ替え＆評価
+                  </Button>
+                </Link>
+              </div>
+            </SheetContent>
+          </Sheet>
+
+          {/* タイトル */}
+          <h1 className="text-lg font-bold text-foreground">クローゼット</h1>
+
+          {/* アイテム追加ボタン */}
+          <AddItemDialog onItemAdded={addItem}>
+            <Button size="sm" className="gap-1 bg-blue-600 hover:bg-blue-700">
+              <Plus className="h-4 w-4" />
+              <span className="hidden sm:inline">アイテム追加</span>
             </Button>
-          </Link>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">服アイテム管理</h1>
-            <p className="text-muted-foreground">お気に入りの服を登録して、コーディネートの幅を広げましょう</p>
-          </div>
+          </AddItemDialog>
         </div>
+      </div>
 
-        <div className="max-w-6xl mx-auto">
-          <div className="flex items-center justify-between mb-8">
-            <AddItemDialog onItemAdded={addItem} />
-          </div>
-
-          <CategoryTabs 
-            items={items}
-            activeCategory={activeCategory}
-            onCategoryChange={setActiveCategory}
-            onDeleteItem={deleteItem}
-          />
-        </div>
-
-        <div className="max-w-6xl mx-auto mt-8">
-          <Link href="/styling">
-            <Button className="w-full">
-              着せ替え・スタイル分析に進む
-            </Button>
-          </Link>
-        </div>
+      {/* メインコンテンツ */}
+      <div className="px-4 py-4">
+        <CategoryTabs 
+          items={items}
+          activeCategory={activeCategory}
+          onCategoryChange={setActiveCategory}
+          onDeleteItem={deleteItem}
+        />
       </div>
     </main>
   )

--- a/components/clothing/add-item-dialog.tsx
+++ b/components/clothing/add-item-dialog.tsx
@@ -21,9 +21,10 @@ import { categoryConfig } from "@/lib/types/clothing"
 
 interface AddItemDialogProps {
   onItemAdded: (item: ClothingItem) => void
+  children?: React.ReactNode
 }
 
-export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
+export function AddItemDialog({ onItemAdded, children }: AddItemDialogProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [selectedCategory, setSelectedCategory] = useState<ClothingCategory>("tops")
   const [selectedPhoto, setSelectedPhoto] = useState<File | null>(null)
@@ -131,10 +132,12 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button className="gap-2">
-          <Plus className="w-4 h-4" />
-          アイテム追加
-        </Button>
+        {children || (
+          <Button className="gap-2">
+            <Plus className="w-4 h-4" />
+            アイテム追加
+          </Button>
+        )}
       </DialogTrigger>
 
       <DialogContent className="max-w-md">

--- a/components/clothing/category-tabs.tsx
+++ b/components/clothing/category-tabs.tsx
@@ -28,16 +28,32 @@ export function CategoryTabs({ items, activeCategory, onCategoryChange, onDelete
 
   return (
     <Tabs value={activeCategory} onValueChange={(value) => onCategoryChange(value as ClothingCategory)}>
-      <TabsList className="grid w-full grid-cols-4 mb-6">
+      <TabsList className="grid w-full grid-cols-4 mb-4 bg-gray-100">
         {Object.entries(categoryConfig).map(([key, config]) => {
           const Icon = iconMap[config.iconName]
           const itemCount = getItemsByCategory(key as ClothingCategory).length
+          const isActive = activeCategory === key
           return (
-            <TabsTrigger key={key} value={key} className="gap-2">
+            <TabsTrigger 
+              key={key} 
+              value={key} 
+              className={`gap-1 text-sm font-medium ${
+                isActive 
+                  ? 'bg-blue-600 text-white' 
+                  : 'text-gray-600 hover:text-gray-800'
+              }`}
+            >
               <Icon className="w-4 h-4" />
-              {config.name}
+              <span className="hidden sm:inline">{config.name}</span>
               {itemCount > 0 && (
-                <Badge variant="secondary" className="ml-1 text-xs">
+                <Badge 
+                  variant="secondary" 
+                  className={`ml-1 text-xs ${
+                    isActive 
+                      ? 'bg-blue-500 text-white' 
+                      : 'bg-gray-200 text-gray-600'
+                  }`}
+                >
                   {itemCount}
                 </Badge>
               )}
@@ -52,13 +68,13 @@ export function CategoryTabs({ items, activeCategory, onCategoryChange, onDelete
         
         return (
           <TabsContent key={key} value={key}>
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+            <div className="grid grid-cols-3 gap-2">
               {categoryItems.map((item) => (
                 <ItemCard key={item.id} item={item} onDelete={onDeleteItem} />
               ))}
 
               {categoryItems.length === 0 && (
-                <div className="col-span-full text-center py-12">
+                <div className="col-span-3 text-center py-12">
                   <div className="text-muted-foreground">
                     <Icon className="w-12 h-12 mx-auto mb-4 opacity-50" />
                     <p className="text-lg font-medium mb-2">まだ{config.name}がありません</p>

--- a/components/clothing/item-card.tsx
+++ b/components/clothing/item-card.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Trash2 } from "lucide-react"
+import { Trash2, Search } from "lucide-react"
 import type { ClothingItem } from "@/lib/types/clothing"
 
 interface ItemCardProps {
@@ -20,28 +20,25 @@ export function ItemCard({ item, onDelete }: ItemCardProps) {
   }
 
   return (
-    <Card className="group hover:shadow-md transition-shadow">
-      <CardContent className="p-4">
-        <div className="aspect-square bg-muted rounded-lg mb-3 flex items-center justify-center overflow-hidden">
+    <Card className="group relative bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-sm transition-shadow">
+      <CardContent className="p-0">
+        <div className="aspect-square bg-gray-50 flex items-center justify-center overflow-hidden relative">
           <img
             src={`/api/items/${item.id}/image`}
             alt="Clothing item"
             className="w-full h-full object-cover"
           />
-        </div>
-
-        <div className="space-y-2">
-          <div className="flex items-center justify-end">
-            <div className="flex gap-1">
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-6 w-6 p-0 text-destructive hover:text-destructive"
-                onClick={handleDelete}
-              >
-                <Trash2 className="w-3 h-3" />
-              </Button>
-            </div>
+          
+          {/* 右下のアイコン */}
+          <div className="absolute bottom-1 right-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0 bg-white/80 hover:bg-white text-gray-600 hover:text-red-600 rounded-full shadow-sm"
+              onClick={handleDelete}
+            >
+              <Trash2 className="w-3 h-3" />
+            </Button>
           </div>
         </div>
       </CardContent>

--- a/tatus
+++ b/tatus
@@ -1,5 +1,5 @@
-[33mb7c547b[m[33m ([m[1;36mHEAD -> [m[1;32mmain[m[33m, [m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m)[m Merge pull request #15 from Engineer-Guild-Hackathon/profile
-[33md1a6bcb[m 顔写真の登録
-[33m68cb984[m RLSポリシーを最適化
-[33m0cbc5f6[m カラーと骨格の設定
-[33m3e2cb31[m Merge branch 'main' into profile
+[33m69c416f[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m)[m Merge pull request #19 from Engineer-Guild-Hackathon/register_clothes
+[33m40ba857[m Merge branch 'main' into register_clothes
+[33m9f1a16c[m アイテムのAI生成を追加
+[33m3f55cc3[m Merge pull request #18 from Engineer-Guild-Hackathon/feature/evaluation-system
+[33ma72384f[m[33m ([m[1;36mHEAD -> [m[1;32mfeature/ui-improvements[m[33m, [m[1;31morigin/feature/evaluation-system[m[33m, [m[1;32mfeature/evaluation-system[m[33m)[m 暫定Dify実装


### PR DESCRIPTION
- ハンバーガーメニューを追加（プロフィール、服登録、着せ替え画面への遷移）
- カテゴリタブを4つ（トップス、ボトムス、シューズ、小物）に整理
- アイテムグリッドを3列レイアウトに変更
- アイテム追加ボタンを右上に配置
- スマートフォンに最適化されたレスポンシブデザインを実装