### PR TITLE
スマートフォン向け着せ替えエディターUI改善

### DIFF
--- a/app/api/evaluate-outfit/route.ts
+++ b/app/api/evaluate-outfit/route.ts
@@ -94,3 +94,4 @@ export async function POST(request: NextRequest) {
   }
 }
 
+

--- a/app/styling/page.tsx
+++ b/app/styling/page.tsx
@@ -1,31 +1,84 @@
+"use client"
+
+import { useState } from "react"
 import { DressUpEditor } from "@/components/dress-up-editor"
 import { OutfitEvaluator } from "@/components/outfit-evaluator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
+import { Menu, User, Shirt, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
 
 export default function StylingPage() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
   return (
     <main className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center gap-4 mb-8">
-          <Link href="/">
-            <Button variant="ghost" size="sm" className="gap-2">
-              <ArrowLeft className="h-4 w-4" />
-              プロフィール設定に戻る
-            </Button>
-          </Link>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">着せ替え & 画像評価</h1>
-            <p className="text-muted-foreground">登録した服で着せ替えを楽しみ、AIで画像を評価しましょう</p>
-          </div>
-        </div>
+      {/* スマートフォン用ヘッダー */}
+      <div className="sticky top-0 z-50 bg-background border-b">
+        <div className="flex items-center justify-between px-4 py-3">
+          {/* ハンバーガーメニュー */}
+          <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="sm" className="p-2">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-64">
+              <SheetHeader>
+                <SheetTitle>メニュー</SheetTitle>
+                <SheetDescription>
+                  アプリの各機能にアクセスできます
+                </SheetDescription>
+              </SheetHeader>
+              <div className="mt-6 space-y-2">
+                <Link href="/profile" onClick={() => setIsMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start gap-2">
+                    <User className="h-4 w-4" />
+                    プロフィール登録
+                  </Button>
+                </Link>
+                <Link href="/clothing" onClick={() => setIsMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start gap-2">
+                    <Shirt className="h-4 w-4" />
+                    服登録
+                  </Button>
+                </Link>
+                <Link href="/styling" onClick={() => setIsMenuOpen(false)}>
+                  <Button variant="ghost" className="w-full justify-start gap-2">
+                    <Sparkles className="h-4 w-4" />
+                    着せ替え＆評価
+                  </Button>
+                </Link>
+              </div>
+            </SheetContent>
+          </Sheet>
 
-        <Tabs defaultValue="editor" className="max-w-6xl mx-auto">
-          <TabsList className="grid w-full grid-cols-2 mb-8">
-            <TabsTrigger value="editor">着せ替えエディター</TabsTrigger>
-            <TabsTrigger value="evaluation">着せ替え評価</TabsTrigger>
+          {/* タイトル */}
+          <h1 className="text-lg font-bold text-foreground">着せ替え＆評価</h1>
+
+          {/* 空のスペース */}
+          <div className="w-10"></div>
+        </div>
+      </div>
+
+      {/* メインコンテンツ */}
+      <div className="px-4 py-4">
+        <Tabs defaultValue="editor" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 mb-4 bg-gray-100">
+            <TabsTrigger value="editor" className="text-sm font-medium">
+              着せ替えエディター
+            </TabsTrigger>
+            <TabsTrigger value="evaluation" className="text-sm font-medium">
+              着せ替え評価
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="editor">
@@ -33,17 +86,9 @@ export default function StylingPage() {
           </TabsContent>
 
           <TabsContent value="evaluation">
-            <OutfitEvaluator imageUrl="" />
+            <OutfitEvaluator />
           </TabsContent>
         </Tabs>
-
-        <div className="max-w-6xl mx-auto mt-8">
-          <Link href="/clothing">
-            <Button variant="outline" className="w-full">
-              服アイテム管理に戻る
-            </Button>
-          </Link>
-        </div>
       </div>
     </main>
   )

--- a/components/dress-up-editor.tsx
+++ b/components/dress-up-editor.tsx
@@ -7,17 +7,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Slider } from "@/components/ui/slider"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import {
   Upload,
   RotateCcw,
   ZoomIn,
   ZoomOut,
-  Layers,
-  Eye,
-  EyeOff,
   Trash2,
   Save,
   Shirt,
@@ -48,7 +42,6 @@ interface PlacedItem {
   y: number
   scale: number
   rotation: number
-  zIndex: number
   visible: boolean
   item: ClothingItem
 }
@@ -126,7 +119,6 @@ export function DressUpEditor() {
       y: 200,
       scale: 1,
       rotation: 0,
-      zIndex: placedItems.length + 1,
       visible: true,
       item,
     }
@@ -298,7 +290,6 @@ export function DressUpEditor() {
           y: 200,
           scale: 1,
           rotation: 0,
-          zIndex: placedItems.length + 1,
           visible: true,
           item,
         }]
@@ -319,86 +310,41 @@ export function DressUpEditor() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto">
-      <div className="flex items-center justify-between mb-8">
-        <div>
-          <h2 className="text-3xl font-bold text-foreground">着せ替えエディター</h2>
-          <p className="text-muted-foreground mt-2">
-            あなたの写真に服をコーディネートして、スタイリングを楽しみましょう
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={() => {
-            setPlacedItems([])
-            setGeneratedDressUpImage(null)
-            setUserPhoto(originalUserPhoto) // 元の写真に戻す
-          }}>
-            <RotateCcw className="w-4 h-4 mr-2" />
-            リセット
-          </Button>
-          {generatedDressUpImage && (
-            <Button variant="outline" onClick={() => {
-              setGeneratedDressUpImage(null)
-              setUserPhoto(originalUserPhoto) // 元の写真に戻す
-              setPlacedItems([]) // アイテムもクリア
-            }}>
-              <Eye className="w-4 h-4 mr-2" />
-              元の画像に戻る
-            </Button>
-          )}
-          <Button 
-            onClick={handleGenerateDressUpImage}
-            disabled={isGeneratingDressUp || placedItems.length === 0}
-          >
-            <Sparkles className="w-4 h-4 mr-2" />
-            {isGeneratingDressUp ? "生成中..." : "AIで着せ替え画像生成"}
-          </Button>
-          <Button onClick={exportOutfit}>
-            <Save className="w-4 h-4 mr-2" />
-            保存
-          </Button>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        {/* Clothing Items Panel */}
-        <div className="lg:col-span-1">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">服アイテム</CardTitle>
-              <p className="text-sm text-muted-foreground mt-1">
-                服をドラッグして人物にドロップするか、クリックして追加
-              </p>
-            </CardHeader>
-            <CardContent>
-              <Tabs value={activeCategory} onValueChange={(value) => setActiveCategory(value as ClothingCategory)}>
-                <TabsList className="grid w-full grid-cols-2 mb-4">
-                  {Object.entries(categoryConfig).map(([key, config]) => {
-                    const Icon = config.icon
-                    return (
-                      <TabsTrigger key={key} value={key} className="text-xs">
-                        <Icon className="w-3 h-3 mr-1" />
-                        {config.name}
-                      </TabsTrigger>
-                    )
-                  })}
+    <div className="h-full flex bg-blue-50">
+      {/* メインコンテンツ - 常に横並びレイアウト */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* 左側：クローゼットパネル */}
+        <div className="w-1/2 border-r bg-white flex flex-col">
+          <div className="px-3 py-2 border-b">
+            <h2 className="text-sm font-bold">クローゼット</h2>
+          </div>
+          
+          <div className="flex-1 overflow-hidden">
+            <Tabs value={activeCategory} onValueChange={(value) => setActiveCategory(value as ClothingCategory)} className="h-full flex flex-col">
+              <div className="px-2 py-2">
+                <TabsList className="grid w-full grid-cols-4 bg-gray-100 h-8">
+                {Object.entries(categoryConfig).map(([key, config]) => {
+                  const Icon = config.icon
+                  return (
+                    <TabsTrigger key={key} value={key} className="text-xs gap-1 h-6">
+                      <Icon className="w-3 h-3" />
+                    </TabsTrigger>
+                  )
+                })}
                 </TabsList>
+              </div>
 
+              <div className="flex-1 overflow-y-auto px-2 pb-2">
                 {Object.entries(categoryConfig).map(([key, config]) => (
-                  <TabsContent key={key} value={key} className="space-y-2">
-                    {getItemsByCategory(key as ClothingCategory).map((item) => (
-                      <div
-                        key={item.id}
-                        className={`p-3 border rounded-lg hover:bg-accent/50 cursor-grab transition-all duration-200 ${
-                          isDragging ? 'opacity-50 scale-95' : ''
-                        }`}
-                        draggable={true}
-                        onDragStart={(e) => handleDragStart(e, item)}
-                        onDragEnd={handleDragEnd}
-                        onClick={() => addClothingItem(item)}
-                      >
-                        <div className="flex items-center gap-3">
-                          <div className="w-12 h-12 bg-muted rounded flex items-center justify-center overflow-hidden">
+                  <TabsContent key={key} value={key} className="h-full">
+                    <div className="grid grid-cols-2 gap-1">
+                      {getItemsByCategory(key as ClothingCategory).map((item) => (
+                        <div
+                          key={item.id}
+                          className="p-1 border rounded hover:bg-accent/50 cursor-pointer transition-all duration-200"
+                          onClick={() => addClothingItem(item)}
+                        >
+                          <div className="aspect-square bg-gray-100 rounded flex items-center justify-center overflow-hidden mb-1">
                             {item.generatedImageUrl ? (
                               <img
                                 src={item.generatedImageUrl}
@@ -406,75 +352,107 @@ export function DressUpEditor() {
                                 className="w-full h-full object-cover"
                               />
                             ) : (
-                              <Upload className="w-4 h-4 text-muted-foreground" />
+                              <Upload className="w-4 h-4 text-gray-400" />
                             )}
                           </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="font-medium text-sm truncate">{item.name}</p>
-                            <div className="flex gap-1 mt-1">
-                              <Badge variant="secondary" className="text-xs">
-                                {item.color}
-                              </Badge>
-                            </div>
-                          </div>
+                          <p className="font-medium text-xs truncate text-center">{item.name}</p>
+                          <Badge variant="secondary" className="text-xs w-full justify-center mt-1 h-4">
+                            {item.color}
+                          </Badge>
                         </div>
-                      </div>
-                    ))}
+                      ))}
+                    </div>
                   </TabsContent>
                 ))}
-              </Tabs>
-            </CardContent>
-          </Card>
+              </div>
+            </Tabs>
+          </div>
         </div>
 
-        {/* Main Canvas */}
-        <div className="lg:col-span-2">
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg">着せ替えキャンバス</CardTitle>
-                <div className="flex items-center gap-2">
-                  <Button size="sm" variant="outline" onClick={() => setCanvasScale(Math.max(0.5, canvasScale - 0.1))}>
-                    <ZoomOut className="w-4 h-4" />
-                  </Button>
-                  <span className="text-sm text-muted-foreground">{Math.round(canvasScale * 100)}%</span>
-                  <Button size="sm" variant="outline" onClick={() => setCanvasScale(Math.min(2, canvasScale + 0.1))}>
-                    <ZoomIn className="w-4 h-4" />
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
+        {/* 右側：着せ替えキャンバス */}
+        <div className="w-1/2 bg-white flex flex-col">
+          <div className="px-3 py-2 border-b">
+            <h2 className="text-sm font-bold">キャンバス</h2>
+          </div>
+          
+          <div className="flex-1 p-2 flex flex-col">
+            {/* 操作ボタン */}
+            <div className="flex items-center justify-center gap-2 mb-3">
+              <Button size="sm" variant="outline" className="h-6 w-6 p-0" onClick={() => setCanvasScale(Math.max(0.5, canvasScale - 0.1))}>
+                <ZoomOut className="w-3 h-3" />
+              </Button>
+              <span className="text-xs text-gray-500">{Math.round(canvasScale * 100)}%</span>
+              <Button size="sm" variant="outline" className="h-6 w-6 p-0" onClick={() => setCanvasScale(Math.min(2, canvasScale + 0.1))}>
+                <ZoomIn className="w-3 h-3" />
+              </Button>
+              <Button 
+                size="sm" 
+                variant="outline" 
+                className="h-6 w-6 p-0"
+                onClick={() => {
+                  setPlacedItems([])
+                  setGeneratedDressUpImage(null)
+                  setUserPhoto(originalUserPhoto)
+                }}
+              >
+                <RotateCcw className="w-3 h-3" />
+              </Button>
+              {generatedDressUpImage && (
+                <Button 
+                  size="sm" 
+                  variant="outline" 
+                  className="h-6 w-6 p-0"
+                  onClick={() => {
+                    setGeneratedDressUpImage(null)
+                    setUserPhoto(originalUserPhoto)
+                    setPlacedItems([])
+                  }}
+                >
+                  <Sparkles className="w-3 h-3" />
+                </Button>
+              )}
+              <Button 
+                size="sm"
+                className="h-6 w-6 p-0"
+                onClick={handleGenerateDressUpImage}
+                disabled={isGeneratingDressUp || placedItems.length === 0}
+              >
+                <Sparkles className="w-3 h-3" />
+              </Button>
+            </div>
+            
+            <div className="flex-1 flex items-center justify-center">
               {!userPhoto ? (
-                <div className="aspect-[3/4] border-2 border-dashed border-border rounded-lg flex flex-col items-center justify-center">
+                <div className="aspect-[3/4] w-full border-2 border-dashed border-gray-300 rounded flex flex-col items-center justify-center">
                   <input type="file" accept="image/*" onChange={handlePhotoUpload} className="hidden" id="user-photo" />
                   <label htmlFor="user-photo" className="cursor-pointer text-center">
-                    <Upload className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                    <p className="text-lg font-medium mb-2">写真をアップロード</p>
-                    <p className="text-sm text-muted-foreground">着せ替えに使用する写真を選択してください</p>
+                    <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+                    <p className="text-sm font-medium mb-1">写真をアップロード</p>
+                    <p className="text-xs text-gray-500">着せ替えに使用する写真を選択してください</p>
                   </label>
                 </div>
               ) : generatedDressUpImage ? (
                 /* 生成された画像を表示（ドラッグ&ドロップ機能付き） */
-                <div className="space-y-2">
+                <div className="w-full space-y-1">
                   <div className="flex items-center justify-between">
-                    <h3 className="text-sm font-medium text-primary">✨ AI生成画像</h3>
+                    <h3 className="text-xs font-medium text-primary">✨ AI生成画像</h3>
                     <Button 
                       size="sm" 
                       variant="outline" 
+                      className="h-5 text-xs px-2"
                       onClick={() => {
                         setGeneratedDressUpImage(null)
-                        setUserPhoto(originalUserPhoto) // 元の写真に戻す
-                        setPlacedItems([]) // アイテムもクリア
+                        setUserPhoto(originalUserPhoto)
+                        setPlacedItems([])
                       }}
                     >
-                      <Eye className="w-3 h-3 mr-1" />
-                      元の画像に戻る
+                      <Sparkles className="w-3 h-3 mr-1" />
+                      元に戻る
                     </Button>
                   </div>
                   <div
-                    className={`relative aspect-[3/4] border rounded-lg overflow-hidden bg-muted transition-all duration-200 ${
-                      isDragOver ? 'border-primary border-4 bg-primary/5 scale-105' : ''
+                    className={`relative aspect-[3/4] border rounded overflow-hidden bg-gray-100 transition-all duration-200 ${
+                      isDragOver ? 'border-primary border-2 bg-primary/5 scale-105' : ''
                     }`}
                     onDragOver={handleDragOver}
                     onDragLeave={handleDragLeave}
@@ -490,20 +468,20 @@ export function DressUpEditor() {
                     {isGeneratingDressUp && (
                       <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
                         <div className="text-center text-white">
-                          <Sparkles className="w-8 h-8 mx-auto mb-2 animate-pulse" />
-                          <p className="font-medium">新しい着せ替え画像を生成中...</p>
-                          <p className="text-sm opacity-80">しばらくお待ちください</p>
+                          <Sparkles className="w-6 h-6 mx-auto mb-1 animate-pulse" />
+                          <p className="text-xs font-medium">新しい着せ替え画像を生成中...</p>
+                          <p className="text-xs opacity-80">しばらくお待ちください</p>
                         </div>
                       </div>
                     )}
                     
                     {/* ドロップ時のオーバーレイ */}
                     {isDragOver && !isGeneratingDressUp && (
-                      <div className="absolute inset-0 bg-primary/20 border-4 border-primary border-dashed flex items-center justify-center">
+                      <div className="absolute inset-0 bg-primary/20 border-2 border-primary border-dashed flex items-center justify-center">
                         <div className="text-center text-primary">
-                          <Sparkles className="w-8 h-8 mx-auto mb-2" />
-                          <p className="font-medium">ここに服をドロップ</p>
-                          <p className="text-sm opacity-80">新しい着せ替え画像を生成します</p>
+                          <Sparkles className="w-6 h-6 mx-auto mb-1" />
+                          <p className="text-xs font-medium">ここに服をドロップ</p>
+                          <p className="text-xs opacity-80">新しい着せ替え画像を生成します</p>
                         </div>
                       </div>
                     )}
@@ -511,182 +489,73 @@ export function DressUpEditor() {
                 </div>
               ) : (
                 /* 元の画像とドラッグ&ドロップ機能を表示 */
-                <div
-                  ref={canvasRef}
-                  className={`relative aspect-[3/4] border rounded-lg overflow-hidden bg-muted transition-all duration-200 ${
-                    isDragOver ? 'border-primary border-4 bg-primary/5 scale-105' : ''
-                  }`}
-                  style={{ transform: `scale(${canvasScale})`, transformOrigin: "top left" }}
-                  onDragOver={handleDragOver}
-                  onDragLeave={handleDragLeave}
-                  onDrop={handleDrop}
-                >
-                  <img
-                    src={URL.createObjectURL(userPhoto) || "/placeholder.svg"}
-                    alt="User"
-                    className="w-full h-full object-cover"
-                  />
-                  
-                  {/* 生成中のローディングオーバーレイ */}
-                  {isGeneratingDressUp && (
-                    <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
-                      <div className="text-center text-white">
-                        <Sparkles className="w-8 h-8 mx-auto mb-2 animate-pulse" />
-                        <p className="font-medium">着せ替え画像を生成中...</p>
-                        <p className="text-sm opacity-80">しばらくお待ちください</p>
-                      </div>
-                    </div>
-                  )}
-                  
-                  {/* ドロップ時のオーバーレイ */}
-                  {isDragOver && !isGeneratingDressUp && (
-                    <div className="absolute inset-0 bg-primary/20 border-4 border-primary border-dashed flex items-center justify-center">
-                      <div className="text-center text-primary">
-                        <Sparkles className="w-8 h-8 mx-auto mb-2" />
-                        <p className="font-medium">ここに服をドロップ</p>
-                        <p className="text-sm opacity-80">着せ替え画像を生成します</p>
-                      </div>
-                    </div>
-                  )}
-
-                  {placedItems
-                    .filter((item) => item.visible)
-                    .sort((a, b) => a.zIndex - b.zIndex)
-                    .map((placedItem) => (
-                      <div
-                        key={placedItem.id}
-                        className={`absolute cursor-move select-none ${
-                          selectedItem === placedItem.id ? "ring-2 ring-primary" : ""
-                        }`}
-                        style={{
-                          left: placedItem.x,
-                          top: placedItem.y,
-                          transform: `scale(${placedItem.scale}) rotate(${placedItem.rotation}deg)`,
-                          zIndex: placedItem.zIndex,
-                        }}
-                        onMouseDown={(e) => handleMouseDown(e, placedItem.id)}
-                      >
-                        <div className="w-20 h-20 bg-primary/20 border-2 border-primary/50 rounded flex items-center justify-center">
-                          <span className="text-xs text-center px-1">{placedItem.item.name}</span>
+                <div className="w-full">
+                  <div
+                    ref={canvasRef}
+                    className={`relative aspect-[3/4] border rounded overflow-hidden bg-gray-100 transition-all duration-200 ${
+                      isDragOver ? 'border-primary border-2 bg-primary/5 scale-105' : ''
+                    }`}
+                    style={{ transform: `scale(${canvasScale})`, transformOrigin: "center" }}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                  >
+                    <img
+                      src={URL.createObjectURL(userPhoto) || "/placeholder.svg"}
+                      alt="User"
+                      className="w-full h-full object-cover"
+                    />
+                    
+                    {/* 生成中のローディングオーバーレイ */}
+                    {isGeneratingDressUp && (
+                      <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                        <div className="text-center text-white">
+                          <Sparkles className="w-6 h-6 mx-auto mb-1 animate-pulse" />
+                          <p className="text-xs font-medium">着せ替え画像を生成中...</p>
+                          <p className="text-xs opacity-80">しばらくお待ちください</p>
                         </div>
                       </div>
-                    ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+                    )}
+                    
+                    {/* ドロップ時のオーバーレイ */}
+                    {isDragOver && !isGeneratingDressUp && (
+                      <div className="absolute inset-0 bg-primary/20 border-2 border-primary border-dashed flex items-center justify-center">
+                        <div className="text-center text-primary">
+                          <Sparkles className="w-6 h-6 mx-auto mb-1" />
+                          <p className="text-xs font-medium">ここに服をドロップ</p>
+                          <p className="text-xs opacity-80">着せ替え画像を生成します</p>
+                        </div>
+                      </div>
+                    )}
 
-        {/* Properties Panel */}
-        <div className="lg:col-span-1">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Layers className="w-4 h-4" />
-                レイヤー管理
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {placedItems.length === 0 ? (
-                <p className="text-sm text-muted-foreground text-center py-4">アイテムを追加してください</p>
-              ) : (
-                <div className="space-y-2">
-                  {placedItems
-                    .sort((a, b) => b.zIndex - a.zIndex)
-                    .map((item) => (
-                      <div
-                        key={item.id}
-                        className={`p-2 border rounded cursor-pointer transition-colors ${
-                          selectedItem === item.id ? "bg-accent border-primary" : "hover:bg-accent/50"
-                        }`}
-                        onClick={() => setSelectedItem(item.id)}
-                      >
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium truncate">{item.item.name}</span>
-                          <div className="flex gap-1">
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-6 w-6 p-0"
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                updatePlacedItem(item.id, { visible: !item.visible })
-                              }}
-                            >
-                              {item.visible ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-6 w-6 p-0 text-destructive hover:text-destructive"
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                removePlacedItem(item.id)
-                              }}
-                            >
-                              <Trash2 className="w-3 h-3" />
-                            </Button>
+                    {placedItems
+                      .filter((item) => item.visible)
+                      .map((placedItem) => (
+                        <div
+                          key={placedItem.id}
+                          className={`absolute cursor-move select-none ${
+                            selectedItem === placedItem.id ? "ring-2 ring-primary" : ""
+                          }`}
+                          style={{
+                            left: placedItem.x,
+                            top: placedItem.y,
+                            transform: `scale(${placedItem.scale}) rotate(${placedItem.rotation}deg)`,
+                          }}
+                          onMouseDown={(e) => handleMouseDown(e, placedItem.id)}
+                        >
+                          <div className="w-12 h-12 bg-primary/20 border-2 border-primary/50 rounded flex items-center justify-center">
+                            <span className="text-xs text-center px-1">{placedItem.item.name}</span>
                           </div>
                         </div>
-                      </div>
-                    ))}
-                </div>
-              )}
-
-              {selectedPlacedItem && (
-                <div className="space-y-4 pt-4 border-t">
-                  <h4 className="font-medium text-sm">アイテム調整</h4>
-
-                  <div>
-                    <Label className="text-xs">サイズ</Label>
-                    <Slider
-                      value={[selectedPlacedItem.scale]}
-                      onValueChange={([value]) => updatePlacedItem(selectedPlacedItem.id, { scale: value })}
-                      min={0.5}
-                      max={2}
-                      step={0.1}
-                      className="mt-2"
-                    />
-                  </div>
-
-                  <div>
-                    <Label className="text-xs">回転</Label>
-                    <Slider
-                      value={[selectedPlacedItem.rotation]}
-                      onValueChange={([value]) => updatePlacedItem(selectedPlacedItem.id, { rotation: value })}
-                      min={-180}
-                      max={180}
-                      step={15}
-                      className="mt-2"
-                    />
-                  </div>
-
-                  <div>
-                    <Label className="text-xs">レイヤー順序</Label>
-                    <Select
-                      value={selectedPlacedItem.zIndex.toString()}
-                      onValueChange={(value) =>
-                        updatePlacedItem(selectedPlacedItem.id, { zIndex: Number.parseInt(value) })
-                      }
-                    >
-                      <SelectTrigger className="mt-2">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Array.from({ length: placedItems.length }, (_, i) => (
-                          <SelectItem key={i + 1} value={(i + 1).toString()}>
-                            レイヤー {i + 1}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      ))}
                   </div>
                 </div>
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   )
 }
+


### PR DESCRIPTION
- スマートフォン向け左右分割レイアウトに変更
- ハンバーガーメニューの重複問題を解決
- クローゼットとキャンバスのレイアウトを最適化
- 操作ボタンをキャンバスエリアに移動
- 文字サイズと要素サイズをスマートフォン向けに調整
- 着せ替え評価タブの画像評価機能を修正
- 重複表示を解消し、クリーンなUIに改善