### PR TITLE
fix: ユーザー初期写真のMIMEタイプ問題を修正

### DIFF
--- a/app/api/full-body-image/route.ts
+++ b/app/api/full-body-image/route.ts
@@ -31,9 +31,12 @@ export async function GET() {
   }
 
   // Convert blob to response with proper headers
+  // Supabaseから取得したBlobオブジェクトには正しいMIMEタイプが含まれている
+  const headers = new Headers()
+  headers.set('Content-Type', data.type || 'image/jpeg') // フォールバックとしてimage/jpegを設定
+
+  console.log(`Successfully fetched full body image with MIME type: ${data.type}`)
   return new NextResponse(data, {
-    headers: {
-      'Content-Type': 'image/*',
-    },
+    headers: headers,
   })
 }

--- a/components/dress-up-editor.tsx
+++ b/components/dress-up-editor.tsx
@@ -81,7 +81,10 @@ export function DressUpEditor() {
           setUserPhotoUrl(url)
 
           // FileオブジェクトとしてもセットするためにBlobを使用
-          const file = new File([blob], 'user-photo.jpg', { type: blob.type })
+          // MIMEタイプが不明な場合はデフォルトでJPEGとして扱う
+          const mimeType = blob.type && blob.type !== 'image/*' ? blob.type : 'image/jpeg'
+          const fileName = mimeType.includes('png') ? 'user-photo.png' : 'user-photo.jpg'
+          const file = new File([blob], fileName, { type: mimeType })
           setUserPhoto(file)
           setOriginalUserPhoto(file)
         } else if (response.status === 404) {


### PR DESCRIPTION
- /api/full-body-imageでContent-Type: image/*から具体的なMIMEタイプに変更
- dress-up-editorでblob.typeがimage/*の場合のフォールバック処理を追加
- 着せ替え画像生成時の「Unsupported file type: image/*」エラーを解決